### PR TITLE
Fix bug on polymorphic belongs_to associations

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -104,7 +104,7 @@ module ModernSearchlogic
 
       def searchlogic_association_finder_method(association, method_name)
         method_name = method_name.to_sym
-        if association.klass.valid_searchlogic_scope?(method_name)
+        if !association.options[:polymorphic] && association.klass.valid_searchlogic_scope?(method_name)
           arity = association.klass.searchlogic_method_arity(method_name)
 
           return {:arity => arity, :block => lambda do |*args|

--- a/spec/lib/modern_searchlogic/column_conditions_spec.rb
+++ b/spec/lib/modern_searchlogic/column_conditions_spec.rb
@@ -116,6 +116,20 @@ describe ModernSearchlogic::ColumnConditions do
         end
       end
     end
+
+    context 'polymorphic association' do
+      let(:user) { User.create!(username: 'Andrew') }
+      let(:user2) { User.create!(username: 'Alice') }
+      let(:post) { user.posts.create!(title: 'first post', body: 'great post') }
+
+      before do
+        user2.votes.create!(voteable: post, vote: 1)
+      end
+
+      specify do
+        Vote.voteable_eq(post).voter_id_eq(user2.id).first.voter.should == user2
+      end
+    end
   end
 
   context 'chaining' do

--- a/spec/shared/db/migrate/20160719181005_add_votes.rb
+++ b/spec/shared/db/migrate/20160719181005_add_votes.rb
@@ -1,0 +1,11 @@
+class AddVotes < ActiveRecord::Migration
+  def change
+    create_table :votes do |t|
+      t.belongs_to :voteable, polymorphic: true, null: false
+      t.integer :vote, null: false
+      t.belongs_to :voter, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/shared/db/schema.rb
+++ b/spec/shared/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526132112) do
+ActiveRecord::Schema.define(version: 20160719181005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,15 @@ ActiveRecord::Schema.define(version: 20150526132112) do
     t.datetime "updated_at",             null: false
     t.integer  "age",        default: 0, null: false
     t.string   "email"
+  end
+
+  create_table "votes", force: :cascade do |t|
+    t.integer  "voteable_id",   null: false
+    t.string   "voteable_type", null: false
+    t.integer  "vote",          null: false
+    t.integer  "voter_id",      null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
 end

--- a/spec/shared/models/comment.rb
+++ b/spec/shared/models/comment.rb
@@ -1,3 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :post
+
+  has_many :votes, as: :voteable
 end

--- a/spec/shared/models/post.rb
+++ b/spec/shared/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ActiveRecord::Base
   belongs_to :user
   has_many :comments
+  has_many :votes, as: :voteable
 
   def self.is_like(something)
     "whoops"

--- a/spec/shared/models/user.rb
+++ b/spec/shared/models/user.rb
@@ -1,3 +1,5 @@
 class User < ActiveRecord::Base
   has_many :posts
+
+  has_many :votes, foreign_key: :voter_id
 end

--- a/spec/shared/models/vote.rb
+++ b/spec/shared/models/vote.rb
@@ -1,0 +1,8 @@
+class Vote < ActiveRecord::Base
+  belongs_to :voteable, polymorphic: true
+  belongs_to :voter, class_name: 'User'
+
+  validates :voteable, :voter, :vote, presence: true
+
+  scope_procedure :voteable_eq, lambda { |v| voteable_type_eq(v.class.base_class.name).voteable_id_eq(v.id) }
+end


### PR DESCRIPTION
- Previously, if you tried to declare a scope or scope_procedure that
  looked like it was hitting a polymorphic association, active record
  would blow up trying to get the `.klass` of the association (because
  of course a polymorphic association doesn't have just one class)
- So, e.g. if you did `scope_procedure :voteable_eq, ...`
  modern_searchlogic would try to ask the `:voteable` scope if it
  responded to `:eq`, which would start by asking that reflected
  association its `klass`. `klass` would blow up deep in active record
- Since we can't ask polymorphic associations if they respond to methods
  anyway (since one model might but another not, and anyway doing a
  double polymorphic join is hard), let's just bail if the association
  is polymorphic
