### PR TITLE
allow nil column values in search fields

### DIFF
--- a/lib/modern_searchlogic/search.rb
+++ b/lib/modern_searchlogic/search.rb
@@ -54,7 +54,7 @@ module ModernSearchlogic
               scope = scope.__send__(k)
             end
           else
-            scope = scope.__send__(k, *v)
+            scope = scope.__send__(k, *Array.wrap([v]))
           end
         end
       end

--- a/spec/lib/modern_searchlogic/searchable_spec.rb
+++ b/spec/lib/modern_searchlogic/searchable_spec.rb
@@ -19,6 +19,14 @@ describe ModernSearchlogic::Searchable do
         user.should_not be_nil
       end
     end
+
+    context 'searches should handle nil column values' do
+      subject do
+        User.search(:username_eq => nil, :email_eq_any => ['d@z.com', 'f@q.com', 'p@l.edu']).to_sql
+      end
+
+      it { should == User.username_eq(nil).email_eq_any('d@z.com', 'f@q.com', 'p@l.edu').to_sql }
+    end
   end
 
   context 'calling methods with 0 arity' do


### PR DESCRIPTION
## What does this PR do?
Allows nil values to be passed in a search.

In the Search#materialize_scope method values were sent using the splat operator 
`scope = scope.__send__(k, *v)`. If the option value is `nil`, this sends an empty array as an argument rather than `nil` wrapped in an array which is what is expected.
