### PR TITLE
Handle non searchlogic conditions when searching

### DIFF
--- a/lib/modern_searchlogic/search.rb
+++ b/lib/modern_searchlogic/search.rb
@@ -56,6 +56,8 @@ module ModernSearchlogic
           else
             scope = scope.__send__(k, *Array.wrap([v]))
           end
+        else
+          scope = scope.where(k => v)
         end
       end
 

--- a/spec/lib/modern_searchlogic/searchable_spec.rb
+++ b/spec/lib/modern_searchlogic/searchable_spec.rb
@@ -99,4 +99,18 @@ describe ModernSearchlogic::Searchable do
              to_sql
     end
   end
+
+  context 'handling non-searchlogic conditions ' do
+    let!(:andrew){UserWithDefaultScope.create!(username: 'andrew', email: 'andrew@test.org')}
+    let!(:nate){UserWithDefaultScope.create!(username: 'nate',  email: 'nate@test.org')}
+
+    it "searches with a non-searchlogic condition" do
+      UserWithDefaultScope.search(username: 'nate').all.should == [nate]
+    end
+
+    it "searches with a searchlogic condition and a non-searchlogic condition" do
+      UserWithDefaultScope.search(username_eq: 'andrew', email: 'andrew@test.org').all.should == [andrew]
+      UserWithDefaultScope.search(username_eq: 'nate', email: 'foo@test.org').all.should == []
+    end
+  end
 end

--- a/spec/shared/models/user_with_default_scope.rb
+++ b/spec/shared/models/user_with_default_scope.rb
@@ -1,0 +1,3 @@
+class UserWithDefaultScope < User
+  default_scope { where('username is not null') }
+end


### PR DESCRIPTION
## What does this PR do?
Allows the `search` method to handle non searchlogic search parameters

When the `search` method was passed a condition that is a plain column name there was no logic branch to handle it. This resulted in matches that were false positives. 

This fix adds a logic branch that sends plain column search conditions to ActiveRecord's where method.