### PR TITLE
Add missing column conditions for not aliases

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -187,6 +187,8 @@ module ModernSearchlogic
         searchlogic_arel_alias :does_not_equal, :not_eq
         searchlogic_arel_alias :ne, :not_eq
         searchlogic_arel_alias :not_eq, :not_eq
+        searchlogic_arel_alias :not, :not_eq
+        searchlogic_arel_alias :is_not, :not_eq
         searchlogic_arel_alias :greater_than, :gt
         searchlogic_arel_alias :gt, :gt
         searchlogic_arel_alias :less_than, :lt

--- a/spec/lib/modern_searchlogic/column_conditions_spec.rb
+++ b/spec/lib/modern_searchlogic/column_conditions_spec.rb
@@ -38,6 +38,8 @@ describe ModernSearchlogic::ColumnConditions do
     it_should_behave_like 'a column condition', :username_is, {:username => 'Andrew'}, 'Andrew'
     it_should_behave_like 'a column condition', :username_does_not_equal, {:username => 'NotAndrew'}, 'Andrew'
     it_should_behave_like 'a column condition', :username_ne, {:username => 'NotAndrew'}, 'Andrew'
+    it_should_behave_like 'a column condition', :username_not, {:username => 'NotAndrew'}, 'Andrew'
+    it_should_behave_like 'a column condition', :username_is_not, {:username => 'NotAndrew'}, 'Andrew'
     it_should_behave_like 'a column condition', :username_like, {:username => 'Andrew Warner'}, 'warn'
     it_should_behave_like 'a column condition', :username_not_like, {:username => 'Andrew Renraw'}, 'warn'
     it_should_behave_like 'a column condition', :username_begins_with, {:username => 'Andrew Warner'}, 'And'


### PR DESCRIPTION
## What does this PR do?
Adds aliases for `not` and `is_not` to `column_conditions`

The aliases for not and is_not are in searchlogic but were missing from modern_searchlogic

Reference:
https://github.com/binarylogic/searchlogic/blob/master/lib/searchlogic/named_scopes/column_conditions.rb#L14