### PR TITLE
Remove return keywords and use colon hash syntax

### DIFF
--- a/spec/lib/modern_searchlogic/column_conditions_spec.rb
+++ b/spec/lib/modern_searchlogic/column_conditions_spec.rb
@@ -215,4 +215,13 @@ describe ModernSearchlogic::ColumnConditions do
       expect { User.posts_is_like }.to raise_error NoMethodError
     end
   end
+
+  context 'boolean conditions' do
+    it 'should have scopes for boolean columns' do
+      inactive = User.create!(active: false)
+      active = User.create!(active: true)
+      User.active.all.should == [active]
+      User.not_active.all.should == [inactive]
+    end
+  end
 end

--- a/spec/shared/config/database.yml
+++ b/spec/shared/config/database.yml
@@ -10,6 +10,7 @@ default: &default
   port: <%= ENV['BOXEN_POSTGRESQL_PORT'] || 5432 %>
   pool: 5
   timeout: 5000
+  username: 'postgres'
 
 development:
   <<: *default

--- a/spec/shared/db/migrate/20190727005829_add_active_to_users.rb
+++ b/spec/shared/db/migrate/20190727005829_add_active_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :active, :boolean
+  end
+end

--- a/spec/shared/db/schema.rb
+++ b/spec/shared/db/schema.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2016_07_19_181005) do
     t.datetime "updated_at", null: false
     t.integer "age", default: 0, null: false
     t.string "email", limit: 255
+    t.boolean "active"
   end
 
   create_table "votes", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
# What does this PR do?

This PR removes explicit return keywords where they are not needed and updates the hashes therein to use colon hash syntax.

These changes are scoped to just the `column_conditions.rb` file. 

This was extracted out of this comment: https://github.com/Genius/modern_searchlogic/pull/5#discussion_r308443222

## Dependencies

This depends on PR #5 