### PR TITLE
Feature: Convert ActiveRecord objects to ids before passing to Arel

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -43,8 +43,18 @@ module ModernSearchlogic
         searchlogic_prefix_conditions[prefix] = method_block
       end
 
+      def searchlogic_extract_arel_compatible_value(value)
+        if value.respond_to?(:map) && !value.acts_like?(:string)
+          value.map { |v| searchlogic_extract_arel_compatible_value(v) }
+        elsif value.is_a?(ActiveRecord::Base)
+          value.id
+        else
+          value
+        end
+      end
+
       def searchlogic_arel_alias(searchlogic_suffix, arel_method, options = {})
-        value_mapper = options.fetch(:map_value, ->(x) { x })
+        value_mapper = options.fetch(:map_value, -> (x) { searchlogic_extract_arel_compatible_value(x) })
 
         searchlogic_suffix_condition "_#{searchlogic_suffix}", options do |column_name, *args|
           values = coerce_and_validate_args_for_arel_aliases!(args, options)


### PR DESCRIPTION
# What does this PR?

This PR updates searchlogic aliases to be able to convert an ActiveRecord object or array of objects to their respective id(s).

ActiveRecord usually does this in the process of sanitizing arrays, but since we're bypassing ActiveRecord and going straight to Arel we need to handle it.

Otherwise Arel will throw errors like "Cannot visit Event" where Event is the name of ActiveRecord class.

See the top commit on this branch for the change-set (while this is including changes from PR #5 and #6).

# Dependencies

* Depends on PR #5 and #6

## Test suite

Everything remains green:

![Screen Shot 2019-07-31 at 12 55 54 PM](https://user-images.githubusercontent.com/967/62231710-96e99b80-b392-11e9-8dba-8b0f0cf0d23e.png)
