### PR TITLE
Update scope_procedure to define singleton methods rather than define scopes

### DIFF
--- a/lib/modern_searchlogic/scope_procedure.rb
+++ b/lib/modern_searchlogic/scope_procedure.rb
@@ -6,7 +6,7 @@ module ModernSearchlogic
           define_singleton_method name do |*args|
             case options
             when Symbol
-              send(options)
+              public_send(options, *args)
             else
               options.call(*args)
             end

--- a/lib/modern_searchlogic/scope_procedure.rb
+++ b/lib/modern_searchlogic/scope_procedure.rb
@@ -3,6 +3,7 @@ module ModernSearchlogic
     def self.included(base)
       base.singleton_class.class_eval do
         def scope_procedure(name, options = nil)
+          self._defined_scopes << name.to_sym
           define_singleton_method name do |*args|
             case options
             when Symbol

--- a/lib/modern_searchlogic/scope_procedure.rb
+++ b/lib/modern_searchlogic/scope_procedure.rb
@@ -2,7 +2,16 @@ module ModernSearchlogic
   module ScopeProcedure
     def self.included(base)
       base.singleton_class.class_eval do
-        alias_method :scope_procedure, :scope
+        def scope_procedure(name, options = nil)
+          define_singleton_method name do |*args|
+            case options
+            when Symbol
+              send(options)
+            else
+              options.call(*args)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/modern_searchlogic/scope_procedure.rb
+++ b/lib/modern_searchlogic/scope_procedure.rb
@@ -3,7 +3,6 @@ module ModernSearchlogic
     def self.included(base)
       base.singleton_class.class_eval do
         def scope_procedure(name, options = nil)
-          self._defined_scopes << name.to_sym
           define_singleton_method name do |*args|
             case options
             when Symbol
@@ -12,6 +11,7 @@ module ModernSearchlogic
               options.call(*args)
             end
           end
+          self._defined_scopes << name.to_sym
         end
       end
     end

--- a/spec/lib/modern_searchlogic/scope_procedure_spec.rb
+++ b/spec/lib/modern_searchlogic/scope_procedure_spec.rb
@@ -38,4 +38,8 @@ describe ModernSearchlogic::ScopeProcedure do
       )
     end
   end
+
+  it 'can combine associations and scope procedures' do
+    User.posts_posts_for_home_page.to_a.should == Post.published.descend_by_published_at.map(&:user)
+  end
 end

--- a/spec/lib/modern_searchlogic/scope_procedure_spec.rb
+++ b/spec/lib/modern_searchlogic/scope_procedure_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe ModernSearchlogic::ScopeProcedure do
+  let!(:post_1) { Post.create!(user: user_1, published_at: Time.now) }
+  let!(:post_2) { Post.create!(user: user_2, published_at: Time.now) }
+  let!(:user_1) { User.create! }
+  let!(:user_2) { User.create! }
+
   specify { described_class.should_not be_nil }
 
   specify do
@@ -9,12 +14,17 @@ describe ModernSearchlogic::ScopeProcedure do
            order(Post.arel_table[:published_at].desc).to_sql
   end
 
-  context 'and the scope procedure does not return a scope' do
-    let!(:post_1) { Post.create!(user: user_1, published_at: Time.now) }
-    let!(:post_2) { Post.create!(user: user_2, published_at: Time.now) }
-    let!(:user_1) { User.create! }
-    let!(:user_2) { User.create! }
+  it 'passes single arguments through' do
+    Post.published_for_user(user_1).should =~ [post_1]
+    Post.published_for_user(user_2).should =~ [post_2]
+    Post.published_for_users(user_1, user_2).should =~ [post_1, post_2]
+  end
 
+  it 'passes multiple arguments through' do
+    Post.published_for_users(user_1, user_2).should =~ [post_1, post_2]
+  end
+
+  context 'and the scope procedure does not return a scope' do
     it 'returns the result of the scope procedure' do
       Post.published_grouped_by_user.should eq(
         user_1 => [post_1],

--- a/spec/lib/modern_searchlogic/scope_procedure_spec.rb
+++ b/spec/lib/modern_searchlogic/scope_procedure_spec.rb
@@ -9,7 +9,7 @@ describe ModernSearchlogic::ScopeProcedure do
   specify { described_class.should_not be_nil }
 
   specify do
-    Post.posts_for_home_page.to_sql.should ==
+    Post.for_home_page.to_sql.should ==
       Post.where(Post.arel_table[:published_at].not_eq(nil)).
            order(Post.arel_table[:published_at].desc).to_sql
   end
@@ -33,13 +33,13 @@ describe ModernSearchlogic::ScopeProcedure do
     end
 
     it 'can be chained on earlier scopes and scope_procedures (that return scopes)' do
-      Post.where(user_id: user_1.id).posts_for_home_page.published_grouped_by_user.should eq(
+      Post.where(user_id: user_1.id).for_home_page.published_grouped_by_user.should eq(
         user_1 => [post_1]
       )
     end
   end
 
   it 'can combine associations and scope procedures' do
-    User.posts_posts_for_home_page.to_a.should == Post.published.descend_by_published_at.map(&:user)
+    User.posts_for_home_page.to_a.should == Post.published.descend_by_published_at.map(&:user)
   end
 end

--- a/spec/lib/modern_searchlogic/scope_procedure_spec.rb
+++ b/spec/lib/modern_searchlogic/scope_procedure_spec.rb
@@ -8,4 +8,24 @@ describe ModernSearchlogic::ScopeProcedure do
       Post.where(Post.arel_table[:published_at].not_eq(nil)).
            order(Post.arel_table[:published_at].desc).to_sql
   end
+
+  context 'and the scope procedure does not return a scope' do
+    let!(:post_1) { Post.create!(user: user_1, published_at: Time.now) }
+    let!(:post_2) { Post.create!(user: user_2, published_at: Time.now) }
+    let!(:user_1) { User.create! }
+    let!(:user_2) { User.create! }
+
+    it 'returns the result of the scope procedure' do
+      Post.published_grouped_by_user.should eq(
+        user_1 => [post_1],
+        user_2 => [post_2]
+      )
+    end
+
+    it 'can be chained on earlier scopes and scope_procedures (that return scopes)' do
+      Post.where(user_id: user_1.id).posts_for_home_page.published_grouped_by_user.should eq(
+        user_1 => [post_1]
+      )
+    end
+  end
 end

--- a/spec/shared/models/post.rb
+++ b/spec/shared/models/post.rb
@@ -13,4 +13,6 @@ class Post < ActiveRecord::Base
 
   scope_procedure :posts_for_home_page, lambda { Post.published.descend_by_published_at }
   scope_procedure :published_grouped_by_user, lambda { published.group_by(&:user) }
+  scope_procedure :published_for_user, lambda { |*users| published.user_id_in(users.map(&:id)) }
+  scope_procedure :published_for_users, :published_for_user
 end

--- a/spec/shared/models/post.rb
+++ b/spec/shared/models/post.rb
@@ -12,4 +12,5 @@ class Post < ActiveRecord::Base
   end
 
   scope_procedure :posts_for_home_page, lambda { Post.published.descend_by_published_at }
+  scope_procedure :published_grouped_by_user, lambda { published.group_by(&:user) }
 end

--- a/spec/shared/models/post.rb
+++ b/spec/shared/models/post.rb
@@ -11,7 +11,7 @@ class Post < ActiveRecord::Base
     where(arel_table[:published_at].not_eq(nil))
   end
 
-  scope_procedure :posts_for_home_page, lambda { Post.published.descend_by_published_at }
+  scope_procedure :for_home_page, lambda { Post.published.descend_by_published_at }
   scope_procedure :published_grouped_by_user, lambda { published.group_by(&:user) }
   scope_procedure :published_for_user, lambda { |*users| published.user_id_in(users.map(&:id)) }
   scope_procedure :published_for_users, :published_for_user


### PR DESCRIPTION
# What does this PR do?

This change-set allows procs passed in to return something that is not a scope. E.g.

```ruby
scope_procedure :published_grouped_by_user, lambda { published.group_by(&:user) }
```

In the above the result of calling "published_grouped_by_user" should be a hash where the keys are the user record and the values are the post records for that user, but before this change-set the result would be an ActiveRecord::Relation which would ignore the group_by operation.

Oh the group_by operation still got called, it just had nothing to do with the return value.

## Test Plan

Here are the test results from my local machine:

![Screen Shot 2019-08-01 at 10 49 10 AM](https://user-images.githubusercontent.com/967/62303552-5f3e2a80-b44a-11e9-958c-8dc695687cb9.png)
