### PR TITLE
Running the test suite on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,32 @@ langauge: ruby
 sudo: false
 cache: bundler
 
-branches:
-  only: master
-
-rvm:
-  - 2.3.7
-  - 2.5.3
-
-gemfile:
-  - gemfiles/rails_3.gemfile
-  - gemfiles/rails_4.gemfile
-  - gemfiles/rails_5.gemfile
-
 matrix:
-  exclude:
-  - rvm: 2.5.3
+  include:
+  - rvm: 2.3.7
     gemfile: gemfiles/rails_3.gemfile
+    env: TEST_APP_DIR=spec/app_rails3
+  - rvm: 2.3.7
+    gemfile: gemfiles/rails_4.gemfile
+    env: TEST_APP_DIR=spec/app_rails4
+  - rvm: 2.3.7
+    gemfile: gemfiles/rails_5.gemfile
+    env: TEST_APP_DIR=spec/app_rails5
+  - rvm: 2.5.5
+    gemfile: gemfiles/rails_4.gemfile
+    env: TEST_APP_DIR=spec/app_rails4
+  - rvm: 2.5.5
+    gemfile: gemfiles/rails_5.gemfile
+    env: TEST_APP_DIR=spec/app_rails5
+
 
 script:
-  - 'psql -lqt | cut -d \| -f 1 | grep -qw modern_searchlogic-app-test || bundle exec appraisal rails-5 "cd spec/app_rails5/ && rake db:create"'
-  - 'bundle exec appraisal rails-5 "cd spec/app_rails5/ && rake db:migrate db:test:prepare && rake db:environment:set RAILS_ENV=test"'
-  - "bundle exec rspec"
+  - export APP_DIR=`pwd`
+  - bundle install
+  - cd $TEST_APP_DIR
+  - bundle exec rake db:create:all
+  - bundle exec rake db:environment:set RAILS_ENV=test
+  - bundle exec rake db:schema:load
+  - cd $APP_DIR
+  - bundle exec rspec
 bundler_args: ""

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ langauge: ruby
 sudo: false
 cache: bundler
 
+before_install:
+  - gem uninstall bundler -x || gem uninstall bundler -a || true
+  - gem install -v 1.16.2 bundler --no-rdoc --no-ri
+
 matrix:
   include:
   - rvm: 2.3.7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+
 # ModernSearchlogic
+
+[![Build Status](https://travis-ci.org/Genius/modern_searchlogic.svg?branch=master)](https://travis-ci.org/Genius/modern_searchlogic)
 
 Searchlogic for Rails 3+
 

--- a/spec/app_rails3/config/initializers/enable_extension_shim.rb
+++ b/spec/app_rails3/config/initializers/enable_extension_shim.rb
@@ -1,0 +1,5 @@
+ActiveRecord::Schema.class_eval do
+  def enable_extension(*args)
+    # no-op: allow schema.rb files from newer versions of Rails to run
+  end
+end

--- a/spec/app_rails3/lib/tasks/db.rake
+++ b/spec/app_rails3/lib/tasks/db.rake
@@ -1,0 +1,3 @@
+task 'db:environment:set' do
+  # no-op: compatibility with newer versions of Rails
+end

--- a/spec/app_rails4/lib/tasks/db.rake
+++ b/spec/app_rails4/lib/tasks/db.rake
@@ -1,0 +1,3 @@
+task 'db:environment:set' do
+  # no-op: compatibility with newer versions of Rails
+end

--- a/spec/shared/db/schema.rb
+++ b/spec/shared/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_07_19_181005) do
+ActiveRecord::Schema.define(version: 2019_07_27_005829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
# What does this PR do?

This PR gets this project running on TravisCI.

## Notable things

• Removes `only: master` so this should run on all pushed branches
• Rails 5 migrations are versioned and will not run Rails 3 and 4 migrations out of the box. Rather than re-jigger how the migrations are made this relies on schema loading on CI.
• `rake db:environment:set` and `ActiveRecord::Schema#enable_extension` have been shimmed on Rails 3 and 4 so all Rails versions can use the same process

