### PR TITLE
Handle arity correctly when scope_options is passed a Proc

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -8,7 +8,7 @@ module ModernSearchlogic
       def valid_searchlogic_scope?(method)
         searchlogic_scope_dynamically_defined?(method) ||
           !!searchlogic_column_condition_method_block(method.to_s) ||
-          _defined_scopes.include?(method)
+          _defined_scopes.include?(method.to_sym)
       end
 
       def dynamically_define_searchlogic_method(method)

--- a/lib/modern_searchlogic/scope_procedure.rb
+++ b/lib/modern_searchlogic/scope_procedure.rb
@@ -3,12 +3,11 @@ module ModernSearchlogic
     def self.included(base)
       base.singleton_class.class_eval do
         def scope_procedure(name, options = nil)
-          define_singleton_method name do |*args|
-            case options
-            when Symbol
+          if options.is_a?(Proc)
+            define_singleton_method(name, &options)
+          else
+            define_singleton_method(name) do |*args|
               public_send(options, *args)
-            else
-              options.call(*args)
             end
           end
           self._defined_scopes << name.to_sym

--- a/spec/lib/modern_searchlogic/scope_procedure_spec.rb
+++ b/spec/lib/modern_searchlogic/scope_procedure_spec.rb
@@ -24,6 +24,12 @@ describe ModernSearchlogic::ScopeProcedure do
     Post.published_for_users(user_1, user_2).should =~ [post_1, post_2]
   end
 
+  it 'handles arity correctly when scope_procedure is passed a proc' do
+    search = Post.search(order: :descend_by_created_at)
+    search.active = true
+    search.all.should =~ [post_1, post_2]
+  end
+
   context 'and the scope procedure does not return a scope' do
     it 'returns the result of the scope procedure' do
       Post.published_grouped_by_user.should eq(

--- a/spec/shared/models/post.rb
+++ b/spec/shared/models/post.rb
@@ -15,4 +15,5 @@ class Post < ActiveRecord::Base
   scope_procedure :published_grouped_by_user, lambda { published.group_by(&:user) }
   scope_procedure :published_for_user, lambda { |*users| published.user_id_in(users.map(&:id)) }
   scope_procedure :published_for_users, :published_for_user
+  scope_procedure :active, lambda { created_at_lt(Time.zone.now) }
 end


### PR DESCRIPTION
## What does this PR do?

* Define singleton method when `scope_options` is passed a Proc rather than just calling the Proc
* Add DefinedScopeSet class to avoid having to call `to_sym` when using `_defined_scopes`



