### PR TITLE
define_method is never valid msl scope

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -6,6 +6,8 @@ module ModernSearchlogic
       end
 
       def valid_searchlogic_scope?(method)
+        return false if method =~ /^define_method_/
+
         searchlogic_scope_dynamically_defined?(method) ||
           !!searchlogic_column_condition_method_block(method.to_s) ||
           _defined_scopes.include?(method.to_sym)


### PR DESCRIPTION
This PR is part of the work to improve performance on Rails 3.

We decided to investigate `ModernSearchlogic::ColumnConditions::ClassMethods#searchlogic_suffix_condition_match` and `ModernSearchlogic::ColumnConditions::ClassMethods#searchlogic_prefix_match` because it was a hotspot in performance sampling. suffix match was taking about 7% of time in self and prefix match was taking about 3% of time. 

without fix:
<img width="1920" alt="no_fix_prefix" src="https://user-images.githubusercontent.com/20496719/74269516-9afa5c80-4cd7-11ea-8e71-bc5c3a1ea131.png">
<img width="1918" alt="no_fix_suffix" src="https://user-images.githubusercontent.com/20496719/74269520-9c2b8980-4cd7-11ea-8bb0-863e19a9eef9.png">

The performance regression was introduced in rails 3 in `ActiveRecord::AttributeMethods`. Whenever `ActiveRecord::AttributeMethods#respond_to?` is called, the attribute methods of a class are generated with `self.class.define_attribute_methods` - [Rails 2](https://github.com/rails/rails/blob/89322cd467fee8d4fcc16f67a9e7fce5817f746f/activerecord/lib/active_record/attribute_methods.rb#L366), [Rails 3](https://github.com/rails/rails/blob/e17e25cd23e8abd45b1706463dd57c90fa6dcb7c/activerecord/lib/active_record/attribute_methods.rb#L168). 

In Rails 2, `define_attribute_methods` just goes through the column hash and generates those methods. In Rails 3, there is first [a check for `respond_to?`](https://github.com/rails/rails/blob/e17e25cd23e8abd45b1706463dd57c90fa6dcb7c/activemodel/lib/active_model/attribute_methods.rb#L266) with a generate method. 

The generate method is formatted like  `generate_method = "define_method_#{matcher.method_missing_target}"`  where matcher is a member of an array of `attribute_method_matchers` defined [here](https://github.com/rails/rails/blob/e17e25cd23e8abd45b1706463dd57c90fa6dcb7c/activemodel/lib/active_model/attribute_methods.rb#L65)  ( i.e. the generate method is not specific to class or method name. ). For every column, respond_to is called for every matcher (number of columns x number of matchers times), so lots of times.

Because SearchLogic extends AR::Base, it looks for whether it can respond to the generate_methods, which ends up going down a complex path of check if the method is a valid searchlogic scope. However, we know that any generate methods are not scopes and are not meant to invoke searchlogic, so we can just short circuit search logic extension if the method is not a valid searchlogic scope.

--

with fix, the times are now 3.4% and 1.5% of time: 

<img width="1915" alt="fix_prefix" src="https://user-images.githubusercontent.com/20496719/74269510-97ff6c00-4cd7-11ea-9b07-a4bc27697048.png">
<img width="1919" alt="fix_suffix" src="https://user-images.githubusercontent.com/20496719/74269515-99c92f80-4cd7-11ea-8f06-db530cad7974.png">

--------
#### Test Plan
-Get performance heatmap and see smaller amount of time spent in msl
hopeful:
-better performance when benchmarking against artist controller
-better performance across the app

--------
#### Communication
- [x] Think about writing a [release notification](https://github.com/Genius/Wiki/wiki/How-to-post-a-new-feature-announcement-aka-release-notification) for a forum e.g. Genius Updates. If the feature is important enough, let Colby write or review the post.
- [x] If this involves substantial new user-facing behavior or interface, show your work to your project backstop, or if they’re unavailable, shoot them an email.
- [x] Most releases merit an internal release notification—at least to the project backstop and other project stakeholders. Have you written a notification to update the relevant people at the company?
- [x] If this is a bugfix, write a release notification that responds to the original bug report thread: `bin/rails generate release_notification bug_is_now_fixed discussion:http://genius.com/discussion/url`

--------
#### Analytics
- [x] Is this a new, user facing feature? If so, have you considered how you will track usage of it?

--------
#### Test Plan
- [x] I wrote a test plan