### PR TITLE
Fix column type discovery running too early

### DIFF
--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -6,7 +6,7 @@ module ModernSearchlogic
       end
 
       def valid_searchlogic_scope?(method)
-        return false unless connection.tables.size > 0
+        return false if connection.tables.empty?
         return false if method =~ /^define_method_/
 
         searchlogic_scope_dynamically_defined?(method) ||
@@ -192,7 +192,8 @@ module ModernSearchlogic
       end
 
       def method_missing(method, *args, &block)
-        return super unless connection.tables.size > 0 && dynamically_define_searchlogic_method(method)
+        return super if connection.tables.empty?
+        return super unless dynamically_define_searchlogic_method(method)
 
         __send__(method, *args, &block)
       end

--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -6,8 +6,7 @@ module ModernSearchlogic
       end
 
       def valid_searchlogic_scope?(method)
-        return false if connection.tables.empty?
-        return false if method =~ /^define_method_/
+        return false if connection.tables.empty? || method =~ /^define_method_/ || abstract_class?
 
         searchlogic_scope_dynamically_defined?(method) ||
           !!searchlogic_column_condition_method_block(method.to_s) ||
@@ -192,7 +191,7 @@ module ModernSearchlogic
       end
 
       def method_missing(method, *args, &block)
-        return super if connection.tables.empty?
+        return super if connection.tables.empty? || abstract_class?
         return super unless dynamically_define_searchlogic_method(method)
 
         __send__(method, *args, &block)

--- a/lib/modern_searchlogic/column_conditions.rb
+++ b/lib/modern_searchlogic/column_conditions.rb
@@ -6,6 +6,7 @@ module ModernSearchlogic
       end
 
       def valid_searchlogic_scope?(method)
+        return false unless connection.tables.size > 0
         return false if method =~ /^define_method_/
 
         searchlogic_scope_dynamically_defined?(method) ||
@@ -191,7 +192,7 @@ module ModernSearchlogic
       end
 
       def method_missing(method, *args, &block)
-        return super unless dynamically_define_searchlogic_method(method)
+        return super unless connection.tables.size > 0 && dynamically_define_searchlogic_method(method)
 
         __send__(method, *args, &block)
       end

--- a/spec/lib/modern_searchlogic/column_conditions_spec.rb
+++ b/spec/lib/modern_searchlogic/column_conditions_spec.rb
@@ -279,4 +279,28 @@ describe ModernSearchlogic::ColumnConditions do
       User.not_active.all.should == [inactive]
     end
   end
+
+  context 'abstract class' do
+    it 'should not try to add searchlogic methods' do
+      class MyApplicationRecord < ActiveRecord::Base
+        self.abstract_class = true
+      end
+
+      MyApplicationRecord.should_not respond_to :id_eq
+    end
+
+    context 'extended by a non-abstract class' do
+      it 'should add searchlogic methods' do
+        class MyApplicationRecord < ActiveRecord::Base
+          self.abstract_class = true
+        end
+
+        class ScopedUser < MyApplicationRecord
+          self.table_name = 'users'
+        end
+
+        ScopedUser.should respond_to :id_eq
+      end
+    end
+  end
 end


### PR DESCRIPTION
In a test environment, or when creating/seeding the database, there are no tables defined in ActiveRecord. This causes an edge case, where, if *any* `method_missing` is called (and it gets to MSL), an error will be thrown. This is because accessing `columns_hash` or `column_names` will cause a query to be made that will fail on the Postgres side (as it expects the table to already be present in the database).

For getting caught up on the memes, see the following:
- https://github.com/Genius/Rap-Genius/pull/15200
- https://github.com/Genius/heroku-buildpack-ruby/pull/14

Additionally, I've fixed another case where column type discovery should not run: abstract classes. This is a common pattern in newer rails apps.

```rb
# Column type discovery should NOT be done here
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  def some_utility_method
    # ...
  end
end

# Column type discovery SHOULD be done here
class User < ApplicationRecord
end
```

-----

Feel free to backport this to Rails 2 - seems pointless since it's On The Way Out (TM) (as it has been for the last decade, but who's counting?!)

## Test Plan

Test suite passes on my [local branch](https://github.com/RDIL/modern_searchlogic/tree/reece/new-rails).
I haven't PR'd in all this work yet, but it allows the tests to run on Ruby 3.